### PR TITLE
Pass --usepkg=n by default

### DIFF
--- a/smartliverebuild/cli.py
+++ b/smartliverebuild/cli.py
@@ -151,7 +151,7 @@ def main(argv):
 			print(p)
 		return 0
 	else:
-		cmd = ['emerge', '--oneshot']
+		cmd = ['emerge', '--oneshot', '--usepkg=n']
 		cmd.extend(args)
 		cmd.extend(packages)
 		out.s2(' '.join(cmd))


### PR DESCRIPTION
Some users set --usepkg in EMERGE_DEFAULT_OPTS, but it obviously makes no sense to remerge a binary package if we already decided it needs to be rebuilt.

Fixes #6.