### PR TITLE
Pass --getbinpkg=n by default

### DIFF
--- a/smartliverebuild/cli.py
+++ b/smartliverebuild/cli.py
@@ -151,7 +151,7 @@ def main(argv):
 			print(p)
 		return 0
 	else:
-		cmd = ['emerge', '--oneshot', '--usepkg=n']
+		cmd = ['emerge', '--oneshot', '--usepkg=n', '--getbinpkg=n']
 		cmd.extend(args)
 		cmd.extend(packages)
 		out.s2(' '.join(cmd))


### PR DESCRIPTION
Similarly to #7, disable `getbinpkg` which might be the default, for example
with `FEATURES=getbinpkg`.