### PR TITLE
Remove possible `getbinpkg` feature from the environment

### DIFF
--- a/smartliverebuild/cli.py
+++ b/smartliverebuild/cli.py
@@ -154,6 +154,12 @@ def main(argv):
 		cmd = ['emerge', '--oneshot', '--usepkg=n', '--getbinpkg=n']
 		cmd.extend(args)
 		cmd.extend(packages)
+		env = os.environ.copy()
+		feats = env.get('FEATURES', '').split()
+		while 'getbinpkg' in feats:
+			feats.remove('getbinpkg')
+		feats.append('-getbinpkg')
+		env['FEATURES'] = ' '.join(feats)
 		out.s2(' '.join(cmd))
-		os.execv('/usr/bin/emerge', cmd)
+		os.execve('/usr/bin/emerge', cmd, env)
 		return 126


### PR DESCRIPTION
My previous commit (e473be02e32d) tried fixing the issue of rebuilding binary
packages (they were fetched from the `$PORTAGE_BINHOST`), but forgot to also
remove the `getbinpkg` feature from the `FEATURES` (either set explicitly or in
`make.conf`).  This patch removes the feature if it is specified in the
environment and explicitly adds `-getbinpkg` to the feature list.