### PR TITLE
Use --usepkg-exclude instead of --usepkg=n

### DIFF
--- a/smartliverebuild/cli.py
+++ b/smartliverebuild/cli.py
@@ -151,7 +151,7 @@ def main(argv):
 			print(p)
 		return 0
 	else:
-		cmd = ['emerge', '--oneshot', '--usepkg=n', '--getbinpkg=n']
+		cmd = ['emerge', '--oneshot', '--getbinpkg=n', '--usepkg-exclude', ' '.join(packages)]
 		cmd.extend(args)
 		cmd.extend(packages)
 		out.s2(' '.join(cmd))


### PR DESCRIPTION
It makes sense to use binpkgs for (build-time) dependencies of the package.